### PR TITLE
Fix childrens_home.py in backend

### DIFF
--- a/back-end/app/models/childrens_home.py
+++ b/back-end/app/models/childrens_home.py
@@ -1,24 +1,38 @@
-from flask import Blueprint, request, jsonify
-from app.models.childrens_home import ChildrenHome
+from datetime import datetime
+from app import db
 
-
-
-home_bp = Blueprint('home', __name__)
-
-@home_bp.route('/homes', methods=['GET'])
-def list_homes():
-    homes = ChildrenHome.query.all()
-    return jsonify([home.to_dict() for home in homes])
-
-@home_bp.route('/homes', methods=['POST'])
-def add_home():
-    data = request.json
-    home = ChildrenHome(**data)
-    if not home.name or not home.location:
-        return jsonify({'error': 'Name and location are required'}), 400
-    return jsonify(home.to_dict()), 201
-
-@home_bp.route('/homes/<int:id>', methods=['GET'])
-def get_home(id):
-    home = ChildrenHome.query.get_or_404(id)
-    return jsonify(home.to_dict())
+class ChildrensHome(db.Model):
+    __tablename__ = 'childrens_homes'
+    
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    location = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text)
+    needs_description = db.Column(db.Text)
+    contact_info = db.Column(db.String(200))
+    website = db.Column(db.String(200))
+    is_active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    
+    # Relationships
+    reviews = db.relationship('Review', backref='home', lazy=True)
+    visits = db.relationship('Visit', backref='home', lazy=True)
+    donations = db.relationship('Donation', backref='home', lazy=True)
+    
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'location': self.location,
+            'description': self.description,
+            'needs_description': self.needs_description,
+            'contact_info': self.contact_info,
+            'website': self.website,
+            'is_active': self.is_active,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+    
+    def __repr__(self):
+        return f'<ChildrensHome {self.name}>'


### PR DESCRIPTION
Refactor `childrens_home.py` to define the `ChildrensHome` model instead of routes, correcting file structure and model availability.

The original `childrens_home.py` in the `models` directory contained Flask route definitions and attempted to import a `ChildrenHome` model that didn't exist. This PR corrects the file to properly define the `ChildrensHome` SQLAlchemy model, which is expected by existing routes in `homes.py`, ensuring correct application structure and functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1ee7fca-0a88-45ef-9ad9-10e5918b2cad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1ee7fca-0a88-45ef-9ad9-10e5918b2cad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>